### PR TITLE
Губкович Александр

### DIFF
--- a/Task.Connector.Tests/UnitTest1.cs
+++ b/Task.Connector.Tests/UnitTest1.cs
@@ -9,8 +9,8 @@ namespace Task.Connector.Tests
         static string requestRightGroupName = "Request";
         static string itRoleRightGroupName = "Role";
         static string delimeter = ":";
-        static string mssqlConnectionString = "";
-        static string postgreConnectionString = "";
+        static string mssqlConnectionString = "Server=localhost;Database=TestAvanpostTask;Trusted_Connection=True;TrustServerCertificate=True;";
+        static string postgreConnectionString = "Server=127.0.0.1;Port=5432;Database=testDb;Username=postgres;Password=1234;";
         static Dictionary<string, string> connectorsCS = new Dictionary<string, string>
         {
             { "MSSQL",$"ConnectionString='{mssqlConnectionString}';Provider='SqlServer.2019';SchemaName='AvanpostIntegrationTestTaskSchema';"},

--- a/Task.Connector.Tests/UnitTest1.cs
+++ b/Task.Connector.Tests/UnitTest1.cs
@@ -32,9 +32,10 @@ namespace Task.Connector.Tests
 
         public IConnector GetConnector(string provider)
         {
-            IConnector connector = new ConnectorDb();
+            IConnector connector = new ConnectorDb() { 
+                Logger = new FileLogger($"{DateTime.Now:dd.MM.yyyy_HH:mm}connector{provider}.Log", $"{DateTime.Now}connector{provider}")
+            };
             connector.StartUp(connectorsCS[provider]);
-            connector.Logger = new FileLogger($"{DateTime.Now}connector{provider}.Log", $"{DateTime.Now}connector{provider}");
             return connector;
         }
 

--- a/Task.Connector/ConnectionStringExtentions.cs
+++ b/Task.Connector/ConnectionStringExtentions.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Task.Connector;
+
+public static partial class ConnectionStringExtentions
+{
+    public static string GetInnerConnectionString(this string connectionString)
+    {
+        return ConnectionStringRegex().Match(connectionString).Groups[1].Value;
+    }
+
+    public static string GetProviderName(this string connectionString)
+    {
+        var providerValue = ProviderRegex().Match(connectionString).Groups[1].Value;
+
+        return providerValue switch
+            {
+                "SqlServer.2019" => "MSSQL",
+                "PostgreSQL.9.5" => "POSTGRE",
+                _ => "UnknownProvider"
+            };
+    }
+
+    [GeneratedRegex("ConnectionString='([^']*)'")]
+    private static partial Regex ConnectionStringRegex();
+
+    [GeneratedRegex("Provider='([^']*)'")]
+    private static partial Regex ProviderRegex();
+}

--- a/Task.Connector/ConnectorDb.cs
+++ b/Task.Connector/ConnectorDb.cs
@@ -2,6 +2,8 @@
 using Task.Integration.Data.Models.Models;
 using Task.Integration.Data.DbCommon;
 using Task.Integration.Data.DbCommon.DbModels;
+using Task.Connector.Helpers;
+using Microsoft.EntityFrameworkCore;
 
 namespace Task.Connector
 {
@@ -62,7 +64,7 @@ namespace Task.Connector
 
                 var user = context.Users.Find(userLogin);
 
-                if (user == null) 
+                if (user == null)
                     return Array.Empty<UserProperty>();
 
                 return new UserProperty[]
@@ -104,15 +106,14 @@ namespace Task.Connector
             {
                 using var context = GetDataContext();
 
-                var user = context.Users.Find(userLogin);
-
-                if (user == null)
-                    throw new Exception($"User with login {userLogin} not found.");
-
+                var user = context.Users.Find(userLogin) 
+                    ?? throw new Exception($"User with login {userLogin} not found.");
+                
                 user.SetPropertiesToUser(properties);
 
                 context.Users.Update(user);
                 context.SaveChanges();
+                Logger.Debug($"User with login {user.Login} updated.");
             }
             catch (Exception ex)
             {
@@ -123,22 +124,123 @@ namespace Task.Connector
 
         public IEnumerable<Permission> GetAllPermissions()
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var itRolePermisions = context.ITRoles
+                    .AsNoTracking()
+                    .Select(x => new Permission(x.Id.ToString() ?? "", x.Name, string.Empty))
+                    .ToList();
+
+                var requestRightPermisions = context.RequestRights
+                    .AsNoTracking()
+                    .Select(x => new Permission(x.Id.ToString() ?? "", x.Name, string.Empty))
+                    .ToList();
+
+                return itRolePermisions.Concat(requestRightPermisions).ToList();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while getting all permissions. \nError: {ex}");
+                throw;
+            }
         }
 
         public void AddUserPermissions(string userLogin, IEnumerable<string> rightIds)
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var user = context.Users.Find(userLogin) 
+                    ?? throw new Exception($"User with login {userLogin} not found.");
+
+                var permissions = rightIds.Select(rightId => rightId.ExtractPermissionIdAndType());
+
+                var userITRoles = permissions
+                    .Where(x => x.Type == PermissionType.ItRole)
+                    .Select(x => new UserITRole() { RoleId = x.Id, UserId = userLogin })
+                    .ToList();
+
+                var userRequestRights = permissions
+                    .Where(x => x.Type == PermissionType.RequestRight)
+                    .Select(x => new UserRequestRight() { RightId = x.Id, UserId = userLogin })
+                    .ToList();
+
+                context.UserITRoles.AddRange(userITRoles);
+                context.UserRequestRights.AddRange(userRequestRights);
+                context.SaveChanges();
+
+                Logger.Debug($"Some permissions added for the user with the login {user.Login}.");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while adding user permissions. \nError: {ex}");
+                throw;
+            }
         }
 
         public void RemoveUserPermissions(string userLogin, IEnumerable<string> rightIds)
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var user = context.Users.Find(userLogin)
+                    ?? throw new Exception($"User with login {userLogin} not found.");
+
+                var permissions = rightIds.Select(rightId => rightId.ExtractPermissionIdAndType());
+
+                var userITRoles = permissions
+                    .Where(x => x.Type == PermissionType.ItRole)
+                    .Select(x => new UserITRole() { RoleId = x.Id, UserId = userLogin })
+                    .ToList();
+
+                var userRequestRights = permissions
+                    .Where(x => x.Type == PermissionType.RequestRight)
+                    .Select(x => new UserRequestRight() { RightId = x.Id, UserId = userLogin })
+                    .ToList();
+
+                context.UserITRoles.RemoveRange(userITRoles);
+                context.UserRequestRights.RemoveRange(userRequestRights);
+                context.SaveChanges();
+
+                Logger.Debug($"Some user permissions with the login {user.Login} was removed.");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while removing user permissions. \nError: {ex}");
+                throw;
+            }
         }
 
         public IEnumerable<string> GetUserPermissions(string userLogin)
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var user = context.Users.Find(userLogin)
+                    ?? throw new Exception($"User with login {userLogin} not found.");
+
+                var itRolesPermissions = context.UserITRoles
+                    .Where(x => x.UserId == userLogin)
+                    .Select(x => $"Role:{x.RoleId}")
+                    .ToList();
+
+                var requestRightsPermissions = context.UserRequestRights
+                    .Where(x => x.UserId == userLogin)
+                    .Select(x => $"Request:{x.RightId}")
+                    .ToList();
+
+                return itRolesPermissions.Concat(requestRightsPermissions).ToList();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while getting user permissions. \nError: {ex}");
+                throw;
+            }
         }
 
         private DataContext GetDataContext()

--- a/Task.Connector/ConnectorDb.cs
+++ b/Task.Connector/ConnectorDb.cs
@@ -1,18 +1,50 @@
 ﻿using Task.Integration.Data.Models;
 using Task.Integration.Data.Models.Models;
+using Task.Integration.Data.DbCommon;
+using Task.Integration.Data.DbCommon.DbModels;
 
 namespace Task.Connector
 {
     public class ConnectorDb : IConnector
     {
+        private DbContextFactory? _contextFactory;
+        private string? _provider;
+
+        public required ILogger Logger { get; set; }
+
         public void StartUp(string connectionString)
         {
-            throw new NotImplementedException();
+            var innnerConnString = connectionString.GetInnerConnectionString();
+            _contextFactory = new DbContextFactory(innnerConnString);
+            _provider = connectionString.GetProviderName();
         }
 
         public void CreateUser(UserToCreate user)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var userForDb = new User {
+                    Login = user.Login
+                };
+
+                var password = new Sequrity
+                {
+                    Password = user.HashPassword,
+                    UserId = user.Login
+                };
+
+                userForDb.SetPropertiesToUser(user.Properties);
+
+                using var context = GetDataContext();
+                context.Users.Add(userForDb);
+                context.Passwords.Add(password);
+                context.SaveChanges();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while creating a user. \nError: {ex}");
+                throw;
+            }
         }
 
         public IEnumerable<Property> GetAllProperties()
@@ -55,6 +87,15 @@ namespace Task.Connector
             throw new NotImplementedException();
         }
 
-        public ILogger Logger { get; set; }
+        private DataContext GetDataContext()
+        {
+            if (_contextFactory == null || _provider == null)
+            {
+                Logger.Error($"Before using {nameof(ConnectorDb)}, you must call the {nameof(StartUp)} method to configure it.");
+                throw new Exception("StartUp method wasn't called.");
+            }
+
+            return _contextFactory.GetContext(_provider);
+        }
     }
 }

--- a/Task.Connector/ConnectorDb.cs
+++ b/Task.Connector/ConnectorDb.cs
@@ -3,7 +3,6 @@ using Task.Integration.Data.Models.Models;
 using Task.Integration.Data.DbCommon;
 using Task.Integration.Data.DbCommon.DbModels;
 using Task.Connector.Helpers;
-using Microsoft.EntityFrameworkCore;
 
 namespace Task.Connector
 {
@@ -129,12 +128,10 @@ namespace Task.Connector
                 using var context = GetDataContext();
 
                 var itRolePermisions = context.ITRoles
-                    .AsNoTracking()
                     .Select(x => new Permission(x.Id.ToString() ?? "", x.Name, string.Empty))
                     .ToList();
 
                 var requestRightPermisions = context.RequestRights
-                    .AsNoTracking()
                     .Select(x => new Permission(x.Id.ToString() ?? "", x.Name, string.Empty))
                     .ToList();
 

--- a/Task.Connector/ConnectorDb.cs
+++ b/Task.Connector/ConnectorDb.cs
@@ -39,6 +39,8 @@ namespace Task.Connector
                 context.Users.Add(userForDb);
                 context.Passwords.Add(password);
                 context.SaveChanges();
+
+                Logger.Debug($"Created user with login {user.Login}.");
             }
             catch (Exception ex)
             {
@@ -49,22 +51,74 @@ namespace Task.Connector
 
         public IEnumerable<Property> GetAllProperties()
         {
-            throw new NotImplementedException();
+            return UserHelper.AllProperties;
         }
 
         public IEnumerable<UserProperty> GetUserProperties(string userLogin)
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var user = context.Users.Find(userLogin);
+
+                if (user == null) 
+                    return Array.Empty<UserProperty>();
+
+                return new UserProperty[]
+                {
+                    new("firstName", user.FirstName),
+                    new("lastName", user.LastName),
+                    new("middleName", user.MiddleName),
+                    new("telephoneNumber", user.TelephoneNumber),
+                    new("isLead", user.IsLead.ToString())
+                };
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while getting user properties. \nError: {ex}");
+                throw;
+            }
         }
 
         public bool IsUserExists(string userLogin)
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var user = context.Users.Find(userLogin);
+
+                return user != null;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while checking user existance. \nError: {ex}");
+                throw;
+            }
         }
 
         public void UpdateUserProperties(IEnumerable<UserProperty> properties, string userLogin)
         {
-            throw new NotImplementedException();
+            try
+            {
+                using var context = GetDataContext();
+
+                var user = context.Users.Find(userLogin);
+
+                if (user == null)
+                    throw new Exception($"User with login {userLogin} not found.");
+
+                user.SetPropertiesToUser(properties);
+
+                context.Users.Update(user);
+                context.SaveChanges();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"An error occurred while updating user properties. \nError: {ex}");
+                throw;
+            }
         }
 
         public IEnumerable<Permission> GetAllPermissions()

--- a/Task.Connector/Helpers/PermissionsHelper.cs
+++ b/Task.Connector/Helpers/PermissionsHelper.cs
@@ -1,0 +1,37 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Task.Connector;
+
+public static partial class PermissionsHelper
+{
+    public static (int Id, PermissionType Type) ExtractPermissionIdAndType(this string rightId)
+    {
+        var match = RightRegex().Match(rightId);
+
+        if (!match.Success)
+        {
+            throw new FormatException("The permission right id must be in the format \"Role:{itRole id}\" or \"Request:{requestRight id}\".");
+        }
+
+        if (!int.TryParse(match.Groups[2].Value, out var id))
+        {
+            throw new FormatException("Invalid id format.");
+        }
+
+        return match.Groups[1].Value switch
+        {
+            "Role" => (id, PermissionType.ItRole),
+            "Request" => (id, PermissionType.RequestRight),
+            _ => throw new FormatException("Invalid permission type.")
+        };
+    }
+
+    [GeneratedRegex(@"(^\S+):(\d+)$")]
+    private static partial Regex RightRegex();
+}
+
+public enum PermissionType
+{
+    ItRole,
+    RequestRight
+}

--- a/Task.Connector/Helpers/UserHelper.cs
+++ b/Task.Connector/Helpers/UserHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Task.Integration.Data.DbCommon.DbModels;
 using Task.Integration.Data.Models.Models;
 
-namespace Task.Connector;
+namespace Task.Connector.Helpers;
 
 public static class UserHelper
 {
@@ -10,7 +10,7 @@ public static class UserHelper
         new("lastName", "Last name"),
         new("middleName", "Middle name"),
         new("telephoneNumber", "Telephone number"),
-        new("isLead", "Is the user a lead?"), 
+        new("isLead", "Is the user a lead?"),
         new("password", "User password"),
     };
 

--- a/Task.Connector/Task.Connector.csproj
+++ b/Task.Connector/Task.Connector.csproj
@@ -9,9 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Task.Integration.Data.Models">
       <HintPath>..\libs\Models\Task.Integration.Data.Models.dll</HintPath>
     </Reference>
+	<Reference Include="Task.Integration.Data.DbCommon">
+		<HintPath>..\libs\CommonForTest\Task.Integration.Data.DbCommon.dll</HintPath>
+	</Reference>
   </ItemGroup>
 
 </Project>

--- a/Task.Connector/UserHelper.cs
+++ b/Task.Connector/UserHelper.cs
@@ -1,0 +1,30 @@
+﻿using Task.Integration.Data.DbCommon.DbModels;
+using Task.Integration.Data.Models.Models;
+
+namespace Task.Connector;
+
+public static class UserHelper
+{
+    public static void SetPropertiesToUser(this User user, IEnumerable<UserProperty> properties)
+    {
+        var isLead = false;
+        var isLeadString = GetPropertyValueOrEmpty(properties, "isLead");
+
+        if (isLeadString != null && !bool.TryParse(isLeadString, out isLead))
+        {
+            throw new ArgumentException("isLead property should be boolean.");
+        } 
+
+        user.FirstName = GetPropertyValueOrEmpty(properties, "firstName");
+        user.LastName = GetPropertyValueOrEmpty(properties, "lastName");
+        user.MiddleName = GetPropertyValueOrEmpty(properties, "middleName");
+        user.TelephoneNumber = GetPropertyValueOrEmpty(properties, "telephoneNumber");
+        user.IsLead = isLead;
+    }
+
+    private static string GetPropertyValueOrEmpty(IEnumerable<UserProperty> properties, string propertyName)
+    {
+        var value = properties.FirstOrDefault(x => x.Name == propertyName)?.Value;
+        return value ?? "";
+    }
+}

--- a/Task.Connector/UserHelper.cs
+++ b/Task.Connector/UserHelper.cs
@@ -5,21 +5,22 @@ namespace Task.Connector;
 
 public static class UserHelper
 {
+    public static readonly Property[] AllProperties = new Property[] {
+        new("firstName", "First name"),
+        new("lastName", "Last name"),
+        new("middleName", "Middle name"),
+        new("telephoneNumber", "Telephone number"),
+        new("isLead", "Is the user a lead?"), 
+        new("password", "User password"),
+    };
+
     public static void SetPropertiesToUser(this User user, IEnumerable<UserProperty> properties)
     {
-        var isLead = false;
-        var isLeadString = GetPropertyValueOrEmpty(properties, "isLead");
-
-        if (isLeadString != null && !bool.TryParse(isLeadString, out isLead))
-        {
-            throw new ArgumentException("isLead property should be boolean.");
-        } 
-
         user.FirstName = GetPropertyValueOrEmpty(properties, "firstName");
         user.LastName = GetPropertyValueOrEmpty(properties, "lastName");
         user.MiddleName = GetPropertyValueOrEmpty(properties, "middleName");
         user.TelephoneNumber = GetPropertyValueOrEmpty(properties, "telephoneNumber");
-        user.IsLead = isLead;
+        user.IsLead = GetPropertyValueOrEmpty(properties, "isLead") == "true";
     }
 
     private static string GetPropertyValueOrEmpty(IEnumerable<UserProperty> properties, string propertyName)


### PR DESCRIPTION
В методе StartUp из connectionString извлекается сама строка подключения и имя провайдера для создания экземпляра класса DbContextFactory, который в сою очередь используется в методе GetContext для создания контекста БД. 

Так как в проекте уже был EF и удобный класс DbContextFactory, то использовал именно их. 

Метод GetUserPermissions возвращает строки в формате "Role:{itRole id}" или "Request:{requestRight id}". Нигде в задании напрямую не указывается что нужно делать именно так, но судя по тестам именно в таком формате передаются списки прав в методы AddUserPermissions и RemoveUserPermissions. 

Библиотека разделяет ItRole и RequestRight, а пользователи просто используют Permissons.

P.S. я пометил поле Logger класса ConnectorDb required атрибутом, для большей безопасности и что бы не делать проверку на null каждый раз. Возможно это частично нарушает обязательное требование наличия пустого конструктора. 

Вот результат тестов:
<img width="818" alt="Снимок экрана 2024-06-25 130545" src="https://github.com/MukhinKirill/task/assets/76650284/3a6a32bb-53ab-4465-a470-cc8ba39e9f20">